### PR TITLE
Fix session ID parsing

### DIFF
--- a/lib/rtsp.js
+++ b/lib/rtsp.js
@@ -124,7 +124,7 @@ export class RtspClient extends EventEmitter {
               let split = line.split(':');
               let data = split.slice(1).join(':').trim();
 
-              headers[split[0].trim()] = !isNaN(parseInt(data)) ? parseInt(data) : data;
+              headers[split[0].trim()] = data.match(/^[0-9]+$/) ? parseInt(data, 10) : data;
             }
           });
 


### PR DESCRIPTION
The previous code has a flaw in it when it comes to parsing numbers:

`parseInt(data)` will return `12` when data is `"12abc"`. This causes flawed session IDs to be kept around.

I've replaced the test with a simple and fast regex, and forced the radix to 10. I ran into this when my session actually had alpha chars in it, and the stream refused to work.

From the [rfc](https://www.ietf.org/rfc/rfc2326.txt):

> 3.4 Session Identifiers
>
>   Session identifiers are opaque strings of arbitrary length. Linear
>   white space must be URL-escaped. A session identifier MUST be chosen
>   randomly and MUST be at least eight octets long to make guessing it
>   more difficult. (See Section 16.)
>
>     session-id   =   1*( ALPHA | DIGIT | safe )
