### PR TITLE
Separate RTP and RTCP packets from the server

### DIFF
--- a/examples/wowza.js
+++ b/examples/wowza.js
@@ -11,9 +11,12 @@ client.connect('rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
 });
 
 // data == packet.payload, just a small convenient thing
-client.on('data', function(channel, data, packet) {
-  if (channel === 0) console.log('RTP Packet', 'ID='+packet.id, 'TS='+packet.timestamp);
-  if (channel === 1) console.log('RTP Control Packet', 'TS='+packet.timestamp);
+client.on('data', function(channel, data, rtp_packet) {
+  console.log('RTP Packet', 'ID=' + rtp_packet.id, 'TS=' + rtp_packet.timestamp, 'M=' + rtp_packet.marker);
+});
+
+client.on('controlData', function(channel, rtcp_packet) {
+  console.log('RTP Control Packet', 'TS=' + rtcp_packet.timestamp, 'PT=' + rtcp_packet.packetType);
 });
 
 // allows you to optionally allow for RTSP logging

--- a/examples/wowza.js
+++ b/examples/wowza.js
@@ -11,8 +11,9 @@ client.connect('rtsp://wowzaec2demo.streamlock.net/vod/mp4:BigBuckBunny_115k.mov
 });
 
 // data == packet.payload, just a small convenient thing
-client.on('data', function(data, packet) {
-  console.log(packet.id);
+client.on('data', function(channel, data, packet) {
+  if (channel === 0) console.log('RTP Packet', 'ID='+packet.id, 'TS='+packet.timestamp);
+  if (channel === 1) console.log('RTP Control Packet', 'TS='+packet.timestamp);
 });
 
 // allows you to optionally allow for RTSP logging

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ const net = require("net");
 const urlParse = require("url");
 const { EventEmitter } = require("events");
 
-const { parseRTPPacket, getMD5Hash, parseTransport } = require('./util.js');
+const { parseRTPPacket, parseRTCPPacket, getMD5Hash, parseTransport } = require('./util.js');
 
 const transform = require("sdp-transform");
 
@@ -26,6 +26,7 @@ class RtspClient extends EventEmitter {
     this.originalPacketLength = -1;
     this.packetLength = -1;
     this.packets = [];
+    this.packet_channel_id = -1;
 
     this.headers = Object.assign({ "User-Agent": "yellowstone/2.0.0" },
         headers || {});
@@ -33,9 +34,11 @@ class RtspClient extends EventEmitter {
 
   _onData(data) {
     if (this.packetLength > 0 || data[0] === 0x24) {
+      // currently processing a RTP or RTCP packet OR the new data starts with a RTP or RTCP marker (0x24 '$')
       let index = 0;
       
       if (this.packetLength > 0) {
+        // Have already received an part of a RTP or RTCP packet. Append the new data
         const packetLength = this.packetLength;
         this.packets.push(data.slice(index, Math.min(this.packetLength, data.length)));
         this.packetLength -= data.length;
@@ -46,19 +49,26 @@ class RtspClient extends EventEmitter {
 
         this.packetLength = -1;
 
-        const packet = parseRTPPacket(Buffer.concat(this.packets));
-        if (packet.length + 16 !== this.originalPacketLength) {
-          throw new Error("Bug in RTSP data framing, please file an issue with the author w/ stacktrace.");
+        let packet;
+        if (this.packet_channel_id === 0) {
+          packet = parseRTPPacket(Buffer.concat(this.packets));
+          if (packet.length + 16 !== this.originalPacketLength) {
+            throw new Error("Bug in RTSP data framing, please file an issue with the author w/ stacktrace.");
+          }
+        }
+        if (this.packet_channel_id === 1) {
+          packet = parseRTCPPacket(Buffer.concat(this.packets));
         }
 
         this.packets = [];
 
-        this.emit("data", packet.payload, packet);
+        this.emit("data", this.packet_channel_id, packet.payload, packet);
 
         index += packetLength;
       }
 
       while (data.length > index && data[index] === 0x24) {
+        this.packet_channel_id = data.readUInt8(index + 1);
         this.originalPacketLength = this.packetLength = data.readUInt16BE(index + 2);
         index += 4;
 
@@ -71,14 +81,20 @@ class RtspClient extends EventEmitter {
 
         this.packetLength = -1;
 
-        const packet = parseRTPPacket(Buffer.concat(this.packets));
-        if (packet.length + 16 !== this.originalPacketLength) {
-          throw new Error("Bug in RTSP data framing, please file an issue with the author w/ stacktrace.");
+        let packet;
+        if (this.packet_channel_id === 0) {
+          packet = parseRTPPacket(Buffer.concat(this.packets));
+          if (packet.length + 16 !== this.originalPacketLength) {
+            throw new Error("Bug in RTSP data framing, please file an issue with the author w/ stacktrace.");
+          }
+        }
+        if (this.packet_channel_id === 1) {
+          packet = parseRTCPPacket(Buffer.concat(this.packets));
         }
 
         this.packets = [];
 
-        this.emit("data", packet.payload, packet);
+        this.emit("data", this.packet_channel_id, packet.payload, packet);
 
         index += this.originalPacketLength;
       }
@@ -198,7 +214,7 @@ class RtspClient extends EventEmitter {
         }
       })
 
-      return this.request("SETUP", { Transport: "RTP/AVP/TCP;interleaved=0-1" });
+      return this.request("SETUP", { Transport: "RTP/AVP/TCP;interleaved=0-1" }); // Channel 0 = RTP. Channel 1 = RTCP
     }).then(headers => {
       if (headers.Transport.split(';')[0] !== "RTP/AVP/TCP") {
         throw new Error("Only RTSP servers supporting RTP/AVP over TCP are supported at this time.");

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ class RtspClient extends EventEmitter {
     this.originalPacketLength = -1;
     this.packetLength = -1;
     this.packets = [];
-    this.packet_channel_id = -1;
+    this.packetChannel = -1;
 
     this.headers = Object.assign({ "User-Agent": "yellowstone/2.0.0" },
         headers || {});
@@ -50,25 +50,26 @@ class RtspClient extends EventEmitter {
         this.packetLength = -1;
 
         let packet;
-        if (this.packet_channel_id === 0) {
+        if (this.packetChannel === 0) {
           packet = parseRTPPacket(Buffer.concat(this.packets));
           if (packet.length + 16 !== this.originalPacketLength) {
             throw new Error("Bug in RTSP data framing, please file an issue with the author w/ stacktrace.");
           }
+          this.emit("data", this.packetChannel, packet.payload, packet);
         }
-        if (this.packet_channel_id === 1) {
+        if (this.packetChannel === 1) {
           packet = parseRTCPPacket(Buffer.concat(this.packets));
+          this.emit("controlData", this.packetChannel, packet);
         }
 
         this.packets = [];
 
-        this.emit("data", this.packet_channel_id, packet.payload, packet);
 
         index += packetLength;
       }
 
       while (data.length > index && data[index] === 0x24) {
-        this.packet_channel_id = data.readUInt8(index + 1);
+        this.packetChannel = data.readUInt8(index + 1);
         this.originalPacketLength = this.packetLength = data.readUInt16BE(index + 2);
         index += 4;
 
@@ -82,19 +83,19 @@ class RtspClient extends EventEmitter {
         this.packetLength = -1;
 
         let packet;
-        if (this.packet_channel_id === 0) {
+        if (this.packetChannel === 0) {
           packet = parseRTPPacket(Buffer.concat(this.packets));
           if (packet.length + 16 !== this.originalPacketLength) {
             throw new Error("Bug in RTSP data framing, please file an issue with the author w/ stacktrace.");
           }
+          this.emit("data", this.packetChannel, packet.payload, packet);
         }
-        if (this.packet_channel_id === 1) {
+        if (this.packetChannel === 1) {
           packet = parseRTCPPacket(Buffer.concat(this.packets));
+          this.emit("controlData", this.packetChannel, packet);
         }
 
         this.packets = [];
-
-        this.emit("data", this.packet_channel_id, packet.payload, packet);
 
         index += this.originalPacketLength;
       }

--- a/lib/util.js
+++ b/lib/util.js
@@ -15,6 +15,15 @@ function parseRTPPacket(buffer) {
   };
 }
 
+function parseRTCPPacket(buffer) {
+  const payload = buffer;
+  const timestamp = buffer.readUInt32BE(16);
+  return {
+    timestamp,
+    payload
+  };
+}
+
 function getMD5Hash(str) {
   const md5 = createHash("md5");
   md5.update(str);
@@ -40,6 +49,7 @@ function parseTransport(transport) {
 
 module.exports = {
   parseRTPPacket,
+  parseRTCPPacket,
   getMD5Hash,
   parseTransport
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,6 +3,7 @@ const { spawn } = require("child_process");
 
 function parseRTPPacket(buffer) {
   const hasExtensions = (buffer[0] << 3) >>> 7;
+  const marker = (buffer[1]) >>> 7;
   const num_csrc_identifiers = (buffer[0] & 0x0F);
 
   const payload = buffer.slice((num_csrc_identifiers * 4) + (hasExtensions ? 16 : 12));
@@ -11,16 +12,19 @@ function parseRTPPacket(buffer) {
   return {
     id: buffer.readUInt16BE(2),
     timestamp: buffer.readUInt32BE(4),
+    marker,
     payload,
     length
   };
 }
 
 function parseRTCPPacket(buffer) {
+  const packetType = (buffer[1]);
   const payload = buffer;
   const timestamp = buffer.readUInt32BE(16);
   return {
     timestamp,
+    packetType,
     payload
   };
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -3,8 +3,9 @@ const { spawn } = require("child_process");
 
 function parseRTPPacket(buffer) {
   const hasExtensions = (buffer[0] << 3) >>> 7;
+  const num_csrc_identifiers = (buffer[0] & 0x0F);
 
-  const payload = buffer.slice(hasExtensions ? 16 : 12);
+  const payload = buffer.slice((num_csrc_identifiers * 4) + (hasExtensions ? 16 : 12));
   const { length } = payload;
 
   return {


### PR DESCRIPTION
This change splits out the RTP and the RTCP packets that are received from the server and is the first step to passing only RTP packets into code that will reconstruct the H264 video stream.

The PR also fixes an issue if the header has a non zero CSRC count.
