### PR TITLE
Emit the mediaSource from the SDP. Used to extract H264 SPS and PPS

### DIFF
--- a/examples/wowza.js
+++ b/examples/wowza.js
@@ -4,26 +4,23 @@ var transform = require('sdp-transform');
 var client = new RtspClient();
 
 // details is a plain Object that includes...
-// format - string
-client.connect('rtsp://mpv.cdn3.bigCDN.com:554/bigCDN/definst/mp4:bigbuckbunnyiphone_400.mp4').then(function(details) {
-  client.play();
-}).catch(function(err) {
-  // console.log(err.stack);
-});
+//   format - string
+//   mediaSource - media portion of the SDP
+//   transport RTP and RTCP channels
 
-// mediaSource returns the portion of the SDP that goes with the video stream.
-// It is used to extract sprop-parameter-sets string contained in the 'fmtp'
-// which holds the SPS and PPS for H264 video
-// Some video formats will not have sprop-parameter-sets so use a Try/Catch
-client.on('mediaSource', function(mediaSource) {
-  //console.log("MediaSource\n",mediaSource);
+client.connect('rtsp://mpv.cdn3.bigCDN.com:554/bigCDN/definst/mp4:bigbuckbunnyiphone_400.mp4').then(function(details) {
+  console.log('Connected. Video format is', details['format']);
   try {
-    var fmtpConfig = transform.parseFmtpConfig(mediaSource.fmtp[0].config);
+    var fmtpConfig = transform.parseFmtpConfig(details['mediaSource'].fmtp[0].config);
     var splitSpropParameterSets = fmtpConfig['sprop-parameter-sets'].split(',');
     var sps_base64 = splitSpropParameterSets[0];
     var pps_base64 = splitSpropParameterSets[1];
     console.log('SPS(base64) is',sps_base64,'PPS(base64) is',pps_base64);
   } catch (err) {}
+  console.log('RTP and RTCP Transport channels are', details['transport']);
+  client.play();
+}).catch(function(err) {
+  // console.log(err.stack);
 });
 
 // data == packet.payload, just a small convenient thing

--- a/examples/wowza.js
+++ b/examples/wowza.js
@@ -1,4 +1,5 @@
 var RtspClient = require('../lib').RtspClient;
+var transform = require('sdp-transform');
 
 var client = new RtspClient();
 
@@ -8,6 +9,21 @@ client.connect('rtsp://mpv.cdn3.bigCDN.com:554/bigCDN/definst/mp4:bigbuckbunnyip
   client.play();
 }).catch(function(err) {
   // console.log(err.stack);
+});
+
+// mediaSource returns the portion of the SDP that goes with the video stream.
+// It is used to extract sprop-parameter-sets string contained in the 'fmtp'
+// which holds the SPS and PPS for H264 video
+// Some video formats will not have sprop-parameter-sets so use a Try/Catch
+client.on('mediaSource', function(mediaSource) {
+  //console.log("MediaSource\n",mediaSource);
+  try {
+    var fmtpConfig = transform.parseFmtpConfig(mediaSource.fmtp[0].config);
+    var splitSpropParameterSets = fmtpConfig['sprop-parameter-sets'].split(',');
+    var sps_base64 = splitSpropParameterSets[0];
+    var pps_base64 = splitSpropParameterSets[1];
+    console.log('SPS(base64) is',sps_base64,'PPS(base64) is',pps_base64);
+  } catch (err) {}
 });
 
 // data == packet.payload, just a small convenient thing

--- a/lib/index.js
+++ b/lib/index.js
@@ -215,6 +215,8 @@ class RtspClient extends EventEmitter {
         }
       })
 
+      this.emit("mediaSource", mediaSource);
+
       return this.request("SETUP", { Transport: "RTP/AVP/TCP;interleaved=0-1" }); // Channel 0 = RTP. Channel 1 = RTCP
     }).then(headers => {
       if (headers.Transport.split(';')[0] !== "RTP/AVP/TCP") {

--- a/lib/index.js
+++ b/lib/index.js
@@ -139,6 +139,7 @@ class RtspClient extends EventEmitter {
     const { hostname, port } = urlParse.parse((this._url = url));
     // mutable
     let format = "";
+    let mediaSource = ""; // part of SDP
 
     return new Promise((resolve, reject) => {
       // set later, mutable
@@ -189,8 +190,6 @@ class RtspClient extends EventEmitter {
     }).then(obj => {
       const sdp = transform.parse(obj.mediaHeaders.join("\r\n"));
 
-      // mutable, set by forEach
-      let mediaSource;
       sdp.media.forEach(media => {
         if (media.type === "video" && media.protocol === "RTP/AVP") {
           mediaSource = media;
@@ -215,8 +214,6 @@ class RtspClient extends EventEmitter {
         }
       })
 
-      this.emit("mediaSource", mediaSource);
-
       return this.request("SETUP", { Transport: "RTP/AVP/TCP;interleaved=0-1" }); // Channel 0 = RTP. Channel 1 = RTCP
     }).then(headers => {
       if (headers.Transport.split(';')[0] !== "RTP/AVP/TCP") {
@@ -232,6 +229,7 @@ class RtspClient extends EventEmitter {
 
       return {
         format,
+        mediaSource,
         transport
       };
     });


### PR DESCRIPTION
I would like to expand the example to dump the H264 video received from Wowza to a .264 video file which can then be replayed by vlc or ffmpeg (etc)

To implement this we need to extract the SPS and PPS from the SDP and write it to a file (to describe the H264 video data) and then parse the RTP frames to extract the H264 NAL Units and write them to the file.

This is the first step towards this by Emitting the part of the SDP that contains the SPS and PPS