### PR TITLE
Re-write _onData to handle messages and raw data split over packets

### DIFF
--- a/examples/wowza.js
+++ b/examples/wowza.js
@@ -10,8 +10,6 @@ const filename = 'video.264';
 
 var client = new RtspClient();
 var h264File;
-var clientSsrc = getRandomIntInclusive(1,0xffffffff);
-
 
 // details is a plain Object that includes...
 //   format - string
@@ -44,22 +42,7 @@ client.on('data', function(channel, data, packet) {
 // control data is for RTCP packets
 client.on('controlData', function(channel, rtcpPacket) {
   console.log('RTCP Control Packet', 'TS=' + rtcpPacket.timestamp, 'PT=' + rtcpPacket.packetType);
-  let rtcpReceiverReport = new Buffer(8);
-  const version = 2;
-  const padding_bit = 0;
-  const report_count = 0; // an empty packet
-  const packet_type = 201; // rtcpReceiverReport
-  const length = 1; // num 32 bit words minus 1
-  rtcpReceiverReport[0] = (version << 6) + (padding_bit << 5) + report_count;
-  rtcpReceiverReport[1] = packet_type;
-  rtcpReceiverReport[2] = (length >> 8) & 0xFF;
-  rtcpReceiverReport[3] = (length >> 0) & 0XFF;
-  rtcpReceiverReport[4] = (clientSsrc >> 24) & 0xFF;
-  rtcpReceiverReport[5] = (clientSsrc >> 16) & 0xFF;
-  rtcpReceiverReport[6] = (clientSsrc >> 8) & 0xFF;
-  rtcpReceiverReport[7] = (clientSsrc >> 0) & 0xFF;
-  client.sendInterleavedData(channel,rtcpReceiverReport);
-  
+  client.sendEmptyReceiverReport(channel);
 });
 
 // allows you to optionally allow for RTSP logging
@@ -68,9 +51,3 @@ client.on('log', function(data, prefix) {
   console.log(prefix + ': ' + data);
 });
 
-
-function getRandomIntInclusive(min, max) {
-  min = Math.ceil(min);
-  max = Math.floor(max);
-  return Math.floor(Math.random() * (max - min + 1)) + min;
-}

--- a/examples/wowza.js
+++ b/examples/wowza.js
@@ -44,6 +44,23 @@ client.on('data', function(channel, data, packet) {
 // control data is for RTCP packets
 client.on('controlData', function(channel, rtcpPacket) {
   console.log('RTCP Control Packet', 'TS=' + rtcpPacket.timestamp, 'PT=' + rtcpPacket.packetType);
+  let rtcpReceiverReport = new Buffer(8);
+  const version = 2;
+  const padding_bit = 0;
+  const report_count = 0; // an empty packet
+  const packet_type = 201; // rtcpReceiverReport
+  const length = 1; // num 32 bit words minus 1
+  const ssrc = 12345; // unique ID
+  rtcpReceiverReport[0] = (version << 6) + (padding_bit << 5) + report_count;
+  rtcpReceiverReport[1] = packet_type;
+  rtcpReceiverReport[2] = (length >> 8) & 0xFF;
+  rtcpReceiverReport[3] = (length >> 0) & 0XFF;
+  rtcpReceiverReport[4] = (ssrc >> 24) & 0xFF;
+  rtcpReceiverReport[5] = (ssrc >> 16) & 0xFF;
+  rtcpReceiverReport[6] = (ssrc >> 8) & 0xFF;
+  rtcpReceiverReport[7] = (ssrc >> 0) & 0xFF;
+  client.sendInterleavedData(channel,rtcpReceiverReport);
+  
 });
 
 // allows you to optionally allow for RTSP logging

--- a/examples/wowza.js
+++ b/examples/wowza.js
@@ -1,32 +1,39 @@
+// Yellowstone Example.
+// Connect to the RTSP server
+// Once connected, open a file, write the SPS and PPS and then start streaming
+
 var RtspClient = require('../lib').RtspClient;
 var transform = require('sdp-transform');
+var fs = require('fs');
+var output_fd;
+var output_stream;
 
 var client = new RtspClient();
+const filename = 'video.264';
+const url = 'rtsp://mpv.cdn3.bigCDN.com:554/bigCDN/definst/mp4:bigbuckbunnyiphone_400.mp4';
+const header = new Buffer.from([0x00,0x00,0x00,0x01]);
+var   rtpPackets = [];
+
 
 // details is a plain Object that includes...
 //   format - string
 //   mediaSource - media portion of the SDP
 //   transport RTP and RTCP channels
 
-client.connect('rtsp://mpv.cdn3.bigCDN.com:554/bigCDN/definst/mp4:bigbuckbunnyiphone_400.mp4').then(function(details) {
+client.connect(url).then(function(details) {
   console.log('Connected. Video format is', details['format']);
-  try {
-    var fmtpConfig = transform.parseFmtpConfig(details['mediaSource'].fmtp[0].config);
-    var splitSpropParameterSets = fmtpConfig['sprop-parameter-sets'].split(',');
-    var sps_base64 = splitSpropParameterSets[0];
-    var pps_base64 = splitSpropParameterSets[1];
-    console.log('SPS(base64) is',sps_base64,'PPS(base64) is',pps_base64);
-  } catch (err) {}
-  console.log('RTP and RTCP Transport channels are', details['transport']);
+
+  // Open the output file
+  output_stream = fs.createWriteStream(filename);
+  processConnectionDetails(details);
   client.play();
-}).catch(function(err) {
-  // console.log(err.stack);
 });
 
 // data == packet.payload, just a small convenient thing
 // data is for RTP packets
 client.on('data', function(channel, data, packet) {
   console.log('RTP Packet', 'ID=' + packet.id, 'TS=' + packet.timestamp, 'M=' + packet.marker);
+  processRTPPacket(packet);
 });
 
 // control data is for RTCP packets
@@ -39,3 +46,97 @@ client.on('controlData', function(channel, rtcpPacket) {
 client.on('log', function(data, prefix) {
   console.log(prefix + ': ' + data);
 });
+
+
+function processConnectionDetails(details) {
+  const fmtpConfig = transform.parseFmtpConfig(details['mediaSource'].fmtp[0].config);
+  const splitSpropParameterSets = fmtpConfig['sprop-parameter-sets'].split(',');
+  const sps_base64 = splitSpropParameterSets[0];
+  const pps_base64 = splitSpropParameterSets[1];
+  const sps = new Buffer(sps_base64,'base64');
+  const pps = new Buffer(pps_base64,'base64');
+  output_stream.write(header);
+  output_stream.write(sps);
+  output_stream.write(header);
+  output_stream.write(pps);
+};
+
+function processRTPPacket(packet) {
+  // accumatate packets with the Marker set to 0
+  // when Marker is set to 1 pass the group of packets to processRTPFrame()
+  rtpPackets.push(packet.payload);
+  if (packet.marker == 1) {
+    processRTPFrame(rtpPackets);
+    rtpPackets = [];
+  }
+}
+
+var temp_buffer = [];
+function processRTPFrame(rtpPackets) {
+  let nals = [];
+
+  for (let i = 0; i < rtpPackets.length; i++) {
+    const packet = rtpPackets[i];
+    const nal_header_f_bit = (packet[0] >> 7) & 0x01;
+    const nal_header_nri = (packet[0] >> 5) & 0x03;
+    const nal_header_type = (packet[0] >> 0) & 0x1F;
+
+    if (nal_header_type >= 1 && nal_header_type <= 23) { // Normal NAL. Not fragmented
+      nals.push(packet);
+    } else if (nal_header_type == 24) { // Aggregation type STAP-A. Multiple NAls in one RTP Packet
+      let ptr = 1; // start after the nal_header_type which was '24'
+      // if we have at least 2 more bytes (the 16 bit size) then consume more data
+      while (ptr + 2 < (packet.length - 1))
+      {
+          let size = (packet[ptr] << 8) + (packet[ptr + 1] << 0);
+          ptr = ptr + 2;
+          nals.push(packet.slice(ptr,ptr+size));
+          ptr = ptr + size;
+      }
+    } else if (nal_header_type == 25) { // STAP-B
+      // Not supported
+    } else if (nal_header_type == 26) { // MTAP-16
+      // Not supported
+    } else if (nal_header_type == 27) { // MTAP-24
+      // Not supported
+    } else if (nal_header_type == 28) { // Frag FU-A
+      // NAL is split over several RTP packets
+      // Accumulate them in a tempoary buffer
+      // Parse Fragmentation Unit Header
+      const fu_header_s = (packet[1] >> 7) & 0x01;  // start marker
+      const fu_header_e = (packet[1] >> 6) & 0x01;  // end marker
+      const fu_header_r = (packet[1] >> 5) & 0x01;  // reserved. should be 0
+      const fu_header_type = (packet[1] >> 0) & 0x1F; // Original NAL unit header
+
+      // Check Start and End flags
+      if (fu_header_s == 1 && fu_header_e == 0) { // Start of Fragment}
+        const reconstructed_nal_type = (nal_header_f_bit << 7)
+                                      + (nal_header_nri << 5)
+                                      + fu_header_type;
+        temp_buffer = [];
+        temp_buffer.push(reconstructed_nal_type);
+
+        // copy the rest of the RTP payload to the temp buffer
+        for (let x=2; x< packet.length;x++) temp_buffer.push(packet[x]);
+      }
+
+      if (fu_header_s == 0 && fu_header_e == 0) { // Middle part of fragment}
+        for (let x=2; x< packet.length;x++) temp_buffer.push(packet[x]);
+      }
+
+      if (fu_header_s == 0 && fu_header_e == 1) { // End of fragment}
+        for (let x=2; x< packet.length;x++) temp_buffer.push(packet[x]);
+        nals.push(Buffer.from(temp_buffer));
+      }
+    } else if (nal_header_type == 29) { // Frag FU-B
+      // Not supported
+    }
+  }
+
+  // Write out all the NALs
+  for (let x = 0; x < nals.length; x++) {
+    output_stream.write(header);
+    output_stream.write(nals[x]);
+  }
+
+}

--- a/examples/wowza.js
+++ b/examples/wowza.js
@@ -27,6 +27,11 @@ client.connect(url).then(function(details) {
   output_stream = fs.createWriteStream(filename);
   processConnectionDetails(details);
   client.play();
+
+  // Start a Timer to send OPTIONS every 20 seconds to keep stream alive
+  setInterval(function() {
+    client.request("OPTIONS");
+    },20*1000);
 });
 
 // data == packet.payload, just a small convenient thing

--- a/examples/wowza.js
+++ b/examples/wowza.js
@@ -3,17 +3,15 @@
 // Once connected, open a file, write the SPS and PPS and then start streaming
 
 var RtspClient = require('../lib').RtspClient;
-var transform = require('sdp-transform');
-var fs = require('fs');
-var output_fd;
-var output_stream;
+var H264Transport = require('../lib/H264Transport').H264Transport;
+
+const url = 'rtsp://mpv.cdn3.bigCDN.com:554/bigCDN/definst/mp4:bigbuckbunnyiphone_400.mp4';
+const filename = 'video.264';
 
 var client = new RtspClient();
-const filename = 'video.264';
-const url = 'rtsp://mpv.cdn3.bigCDN.com:554/bigCDN/definst/mp4:bigbuckbunnyiphone_400.mp4';
-const header = new Buffer.from([0x00,0x00,0x00,0x01]);
-var   rtpPackets = [];
-var   clientSsrc = getRandomIntInclusive(1,0xffffffff);
+var h264File;
+var clientSsrc = getRandomIntInclusive(1,0xffffffff);
+
 
 // details is a plain Object that includes...
 //   format - string
@@ -24,8 +22,10 @@ client.connect(url).then(function(details) {
   console.log('Connected. Video format is', details['format']);
 
   // Open the output file
-  output_stream = fs.createWriteStream(filename);
-  processConnectionDetails(details);
+  if (details['format'] == 'H264') {
+    h264File = new H264Transport(filename);
+    h264File.processConnectionDetails(details);
+  }
   client.play();
 
   // Start a Timer to send OPTIONS every 20 seconds to keep stream alive
@@ -38,7 +38,7 @@ client.connect(url).then(function(details) {
 // data is for RTP packets
 client.on('data', function(channel, data, packet) {
   console.log('RTP Packet', 'ID=' + packet.id, 'TS=' + packet.timestamp, 'M=' + packet.marker);
-  processRTPPacket(packet);
+  if (h264File) h264File.processRTPPacket(packet);
 });
 
 // control data is for RTCP packets
@@ -73,97 +73,4 @@ function getRandomIntInclusive(min, max) {
   min = Math.ceil(min);
   max = Math.floor(max);
   return Math.floor(Math.random() * (max - min + 1)) + min;
-}
-
-function processConnectionDetails(details) {
-  const fmtpConfig = transform.parseFmtpConfig(details['mediaSource'].fmtp[0].config);
-  const splitSpropParameterSets = fmtpConfig['sprop-parameter-sets'].split(',');
-  const sps_base64 = splitSpropParameterSets[0];
-  const pps_base64 = splitSpropParameterSets[1];
-  const sps = new Buffer(sps_base64,'base64');
-  const pps = new Buffer(pps_base64,'base64');
-  output_stream.write(header);
-  output_stream.write(sps);
-  output_stream.write(header);
-  output_stream.write(pps);
-};
-
-function processRTPPacket(packet) {
-  // accumatate packets with the Marker set to 0
-  // when Marker is set to 1 pass the group of packets to processRTPFrame()
-  rtpPackets.push(packet.payload);
-  if (packet.marker == 1) {
-    processRTPFrame(rtpPackets);
-    rtpPackets = [];
-  }
-}
-
-var temp_buffer = [];
-function processRTPFrame(rtpPackets) {
-  let nals = [];
-
-  for (let i = 0; i < rtpPackets.length; i++) {
-    const packet = rtpPackets[i];
-    const nal_header_f_bit = (packet[0] >> 7) & 0x01;
-    const nal_header_nri = (packet[0] >> 5) & 0x03;
-    const nal_header_type = (packet[0] >> 0) & 0x1F;
-
-    if (nal_header_type >= 1 && nal_header_type <= 23) { // Normal NAL. Not fragmented
-      nals.push(packet);
-    } else if (nal_header_type == 24) { // Aggregation type STAP-A. Multiple NAls in one RTP Packet
-      let ptr = 1; // start after the nal_header_type which was '24'
-      // if we have at least 2 more bytes (the 16 bit size) then consume more data
-      while (ptr + 2 < (packet.length - 1))
-      {
-          let size = (packet[ptr] << 8) + (packet[ptr + 1] << 0);
-          ptr = ptr + 2;
-          nals.push(packet.slice(ptr,ptr+size));
-          ptr = ptr + size;
-      }
-    } else if (nal_header_type == 25) { // STAP-B
-      // Not supported
-    } else if (nal_header_type == 26) { // MTAP-16
-      // Not supported
-    } else if (nal_header_type == 27) { // MTAP-24
-      // Not supported
-    } else if (nal_header_type == 28) { // Frag FU-A
-      // NAL is split over several RTP packets
-      // Accumulate them in a tempoary buffer
-      // Parse Fragmentation Unit Header
-      const fu_header_s = (packet[1] >> 7) & 0x01;  // start marker
-      const fu_header_e = (packet[1] >> 6) & 0x01;  // end marker
-      const fu_header_r = (packet[1] >> 5) & 0x01;  // reserved. should be 0
-      const fu_header_type = (packet[1] >> 0) & 0x1F; // Original NAL unit header
-
-      // Check Start and End flags
-      if (fu_header_s == 1 && fu_header_e == 0) { // Start of Fragment}
-        const reconstructed_nal_type = (nal_header_f_bit << 7)
-                                      + (nal_header_nri << 5)
-                                      + fu_header_type;
-        temp_buffer = [];
-        temp_buffer.push(reconstructed_nal_type);
-
-        // copy the rest of the RTP payload to the temp buffer
-        for (let x=2; x< packet.length;x++) temp_buffer.push(packet[x]);
-      }
-
-      if (fu_header_s == 0 && fu_header_e == 0) { // Middle part of fragment}
-        for (let x=2; x< packet.length;x++) temp_buffer.push(packet[x]);
-      }
-
-      if (fu_header_s == 0 && fu_header_e == 1) { // End of fragment}
-        for (let x=2; x< packet.length;x++) temp_buffer.push(packet[x]);
-        nals.push(Buffer.from(temp_buffer));
-      }
-    } else if (nal_header_type == 29) { // Frag FU-B
-      // Not supported
-    }
-  }
-
-  // Write out all the NALs
-  for (let x = 0; x < nals.length; x++) {
-    output_stream.write(header);
-    output_stream.write(nals[x]);
-  }
-
 }

--- a/examples/wowza.js
+++ b/examples/wowza.js
@@ -38,7 +38,7 @@ client.on('data', function(channel, data, packet) {
 
 // control data is for RTCP packets
 client.on('controlData', function(channel, rtcpPacket) {
-  console.log('RTP Control Packet', 'TS=' + rtcpPacket.timestamp, 'PT=' + rtcpPacket.packetType);
+  console.log('RTCP Control Packet', 'TS=' + rtcpPacket.timestamp, 'PT=' + rtcpPacket.packetType);
 });
 
 // allows you to optionally allow for RTSP logging

--- a/examples/wowza.js
+++ b/examples/wowza.js
@@ -13,7 +13,7 @@ const filename = 'video.264';
 const url = 'rtsp://mpv.cdn3.bigCDN.com:554/bigCDN/definst/mp4:bigbuckbunnyiphone_400.mp4';
 const header = new Buffer.from([0x00,0x00,0x00,0x01]);
 var   rtpPackets = [];
-
+var   clientSsrc = getRandomIntInclusive(1,0xffffffff);
 
 // details is a plain Object that includes...
 //   format - string
@@ -50,15 +50,14 @@ client.on('controlData', function(channel, rtcpPacket) {
   const report_count = 0; // an empty packet
   const packet_type = 201; // rtcpReceiverReport
   const length = 1; // num 32 bit words minus 1
-  const ssrc = 12345; // unique ID
   rtcpReceiverReport[0] = (version << 6) + (padding_bit << 5) + report_count;
   rtcpReceiverReport[1] = packet_type;
   rtcpReceiverReport[2] = (length >> 8) & 0xFF;
   rtcpReceiverReport[3] = (length >> 0) & 0XFF;
-  rtcpReceiverReport[4] = (ssrc >> 24) & 0xFF;
-  rtcpReceiverReport[5] = (ssrc >> 16) & 0xFF;
-  rtcpReceiverReport[6] = (ssrc >> 8) & 0xFF;
-  rtcpReceiverReport[7] = (ssrc >> 0) & 0xFF;
+  rtcpReceiverReport[4] = (clientSsrc >> 24) & 0xFF;
+  rtcpReceiverReport[5] = (clientSsrc >> 16) & 0xFF;
+  rtcpReceiverReport[6] = (clientSsrc >> 8) & 0xFF;
+  rtcpReceiverReport[7] = (clientSsrc >> 0) & 0xFF;
   client.sendInterleavedData(channel,rtcpReceiverReport);
   
 });
@@ -69,6 +68,12 @@ client.on('log', function(data, prefix) {
   console.log(prefix + ': ' + data);
 });
 
+
+function getRandomIntInclusive(min, max) {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
 
 function processConnectionDetails(details) {
   const fmtpConfig = transform.parseFmtpConfig(details['mediaSource'].fmtp[0].config);

--- a/lib/H264Transport.js
+++ b/lib/H264Transport.js
@@ -1,0 +1,111 @@
+// Process SDP and RTP packets
+// De-packetize RTP packets to re-create H264 NAL Units
+// Write H264 NAL units to a .264 file
+
+var fs = require('fs');
+var transform = require('sdp-transform');
+
+const header = new Buffer.from([0x00,0x00,0x00,0x01]);
+
+class H264Transport {
+  constructor(filename) {
+    this.output_stream = fs.createWriteStream(filename);
+    this.rtpPackets = [];
+  }
+
+
+  processConnectionDetails(details) {
+    // Extract SPS and PPS from the MediaSource part of the SDP
+    const fmtpConfig = transform.parseFmtpConfig(details['mediaSource'].fmtp[0].config);
+    const splitSpropParameterSets = fmtpConfig['sprop-parameter-sets'].split(',');
+    const sps_base64 = splitSpropParameterSets[0];
+    const pps_base64 = splitSpropParameterSets[1];
+    const sps = new Buffer(sps_base64,'base64');
+    const pps = new Buffer(pps_base64,'base64');
+    this.output_stream.write(header);
+    this.output_stream.write(sps);
+    this.output_stream.write(header);
+    this.output_stream.write(pps);
+  };
+
+  processRTPPacket(packet) {
+    // Accumatate RTP packets
+    this.rtpPackets.push(packet.payload);
+    
+    // When Marker is set to 1 pass the group of packets to processRTPFrame()
+    if (packet.marker == 1) {
+      this.processRTPFrame(this.rtpPackets);
+      this.rtpPackets = [];
+    }
+  }
+
+  processRTPFrame(rtpPackets) {
+    let nals = [];
+    let partialNal = [];
+
+    for (let i = 0; i < rtpPackets.length; i++) {
+      const packet = rtpPackets[i];
+      const nal_header_f_bit = (packet[0] >> 7) & 0x01;
+      const nal_header_nri = (packet[0] >> 5) & 0x03;
+      const nal_header_type = (packet[0] >> 0) & 0x1F;
+
+      if (nal_header_type >= 1 && nal_header_type <= 23) { // Normal NAL. Not fragmented
+        nals.push(packet);
+      } else if (nal_header_type == 24) { // Aggregation type STAP-A. Multiple NAls in one RTP Packet
+        let ptr = 1; // start after the nal_header_type which was '24'
+        // if we have at least 2 more bytes (the 16 bit size) then consume more data
+        while (ptr + 2 < (packet.length - 1)) {
+          let size = (packet[ptr] << 8) + (packet[ptr + 1] << 0);
+          ptr = ptr + 2;
+          nals.push(packet.slice(ptr,ptr+size));
+          ptr = ptr + size;
+        }
+      } else if (nal_header_type == 25) { // STAP-B
+        // Not supported
+      } else if (nal_header_type == 26) { // MTAP-16
+        // Not supported
+      } else if (nal_header_type == 27) { // MTAP-24
+        // Not supported
+      } else if (nal_header_type == 28) { // Frag FU-A
+        // NAL is split over several RTP packets
+        // Accumulate them in a tempoary buffer
+        // Parse Fragmentation Unit Header
+        const fu_header_s = (packet[1] >> 7) & 0x01;  // start marker
+        const fu_header_e = (packet[1] >> 6) & 0x01;  // end marker
+        const fu_header_r = (packet[1] >> 5) & 0x01;  // reserved. should be 0
+        const fu_header_type = (packet[1] >> 0) & 0x1F; // Original NAL unit header
+
+        // Check Start and End flags
+        if (fu_header_s == 1 && fu_header_e == 0) { // Start of Fragment}
+          const reconstructed_nal_type = (nal_header_f_bit << 7)
+                                        + (nal_header_nri << 5)
+                                        + fu_header_type;
+          partialNal = [];
+          partialNal.push(reconstructed_nal_type);
+
+          // copy the rest of the RTP payload to the temp buffer
+          for (let x=2; x< packet.length;x++) partialNal.push(packet[x]);
+        }
+
+        if (fu_header_s == 0 && fu_header_e == 0) { // Middle part of fragment}
+          for (let x=2; x< packet.length;x++) partialNal.push(packet[x]);
+        }
+
+        if (fu_header_s == 0 && fu_header_e == 1) { // End of fragment}
+          for (let x=2; x< packet.length;x++) partialNal.push(packet[x]);
+          nals.push(Buffer.from(partialNal));
+        }
+      } else if (nal_header_type == 29) { // Frag FU-B
+        // Not supported
+      }
+    }
+
+    // Write out all the NALs
+    for (let x = 0; x < nals.length; x++) {
+        this.output_stream.write(header);
+        this.output_stream.write(nals[x]);
+    }
+  }
+}
+
+module.exports = { H264Transport };

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,12 @@ const transform = require("sdp-transform");
 
 const WWW_AUTH_REGEX = new RegExp('([a-z]+)=\'([^,\s]+)\'');
 
+const readStates = {Searching: 0,
+                    ReadingRTSPHeader: 1,
+                    ReadingRTSPPayload: 2,
+                    ReadingRawPacketSize: 3,
+                    ReadingRawPacket: 4};
+
 class RtspClient extends EventEmitter {
   constructor(username, password, headers) {
     super();
@@ -23,116 +29,142 @@ class RtspClient extends EventEmitter {
     this.username = username;
     this.password = password;
 
-    this.originalPacketLength = -1;
-    this.packetLength = -1;
-    this.packets = [];
-    this.packetChannel = -1;
+    this.readState = readStates.Searching;
+
+    this.rtspMessage = []; // RTSP Message
+    this.rtspContentLength = 0; // From Content-Length: in the RTSP message
+    this.rtspStatusLine = "";
+    this.rtspHeaders = [];
+    this.rtspContent = [];
+
+    this.rtspPacketLength = 0;
+    this.rtspPacket;
+    this.rtspPacketPointer = 0;
 
     this.headers = Object.assign({ "User-Agent": "yellowstone/2.0.0" },
         headers || {});
   }
 
   _onData(data) {
-    if (this.packetLength > 0 || data[0] === 0x24) {
-      // currently processing a RTP or RTCP packet OR the new data starts with a RTP or RTCP marker (0x24 '$')
-      let index = 0;
-      
-      if (this.packetLength > 0) {
-        // Have already received an part of a RTP or RTCP packet. Append the new data
-        const packetLength = this.packetLength;
-        this.packets.push(data.slice(index, Math.min(this.packetLength, data.length)));
-        this.packetLength -= data.length;
 
-        if (this.packetLength > 0) {
-          return;
+    let index = 0;
+
+    while (index < data.length) {
+
+      if (this.readState == readStates.Searching && data[index] == 0x24) { // $
+          // found the start of a RTP or RTCP block of data
+          this.rtspMessage = [];
+          this.rtspMessage.push(data[index]);
+          index++;
+          this.readState = readStates.ReadingRawPacketSize;
+      } else if (this.readState == readStates.Searching && data[index] == 0x52) { // 'R'
+          // found the start of a RTSP rtsp_message
+          this.rtspMessage = [];
+          this.rtspMessage.push(data[index]);
+          index++;
+          this.readState = readStates.ReadingRTSPHeader;
+      } else if (this.readState == readStates.ReadingRTSPHeader) {
+        // Reading a RTSP message.
+        
+        // Add character to the rtspMessage
+        // Ignore /r (13) but keep /n (10)
+        if (data[index] != 13) { // \r
+          this.rtspMessage.push(data[index]);
         }
+        index++;
 
-        this.packetLength = -1;
+        // If we have two new lines back to back then we have a complete RTSP command
+        // Note we may still need to read the Content Payload (the body) e.g. the SDP
+        if (this.rtspMessage.length >= 2
+          && this.rtspMessage[this.rtspMessage.length-2] == 10
+          && this.rtspMessage[this.rtspMessage.length-1] == 10) {
 
-        let packet;
-        if (this.packetChannel === 0) {
-          packet = parseRTPPacket(Buffer.concat(this.packets));
-          if (packet.length + 16 !== this.originalPacketLength) {
-            throw new Error("Bug in RTSP data framing, please file an issue with the author w/ stacktrace.");
+          // Parse the Header
+          this.rtspContentLength = 0;
+
+          const ascii_text = String.fromCharCode.apply(null,this.rtspMessage);
+          const lines = ascii_text.split("\n");
+          this.rtspStatusLine = lines[0];
+
+          this.rtspHeaders = {};
+
+          for (let i = 1; i < lines.length; i++) {
+            const line = lines[i];
+
+            const indexOf = line.indexOf(":");
+
+            if (indexOf !== line.length - 1) {
+              const key = line.substring(0, indexOf).trim();
+              const data = line.substring(indexOf + 1).trim();
+              this.rtspHeaders[key] = data.match(/^[0-9]+$/) ? parseInt(data, 10) : data;
+
+              if (key == 'Content-Length') {
+                this.rtspContentLength = parseInt(data,10);
+              }
+            }
           }
-          this.emit("data", this.packetChannel, packet.payload, packet);
-        }
-        if (this.packetChannel === 1) {
-          packet = parseRTCPPacket(Buffer.concat(this.packets));
-          this.emit("controlData", this.packetChannel, packet);
-        }
 
-        this.packets = [];
-
-
-        index += packetLength;
-      }
-
-      while (data.length > index && data[index] === 0x24) {
-        this.packetChannel = data.readUInt8(index + 1);
-        this.originalPacketLength = this.packetLength = data.readUInt16BE(index + 2);
-        index += 4;
-
-        this.packets.push(data.slice(index, Math.min(index + this.packetLength, data.length)));
-        this.packetLength -= (data.length - index);
-
-        if (this.packetLength > 0) {
-          return;
-        }
-
-        this.packetLength = -1;
-
-        let packet;
-        if (this.packetChannel === 0) {
-          packet = parseRTPPacket(Buffer.concat(this.packets));
-          if (packet.length + 16 !== this.originalPacketLength) {
-            throw new Error("Bug in RTSP data framing, please file an issue with the author w/ stacktrace.");
+          if (this.rtspContentLength == 0) {
+            // We can Emit the RTSP message
+            this.emit("log", data, "S->C");
+            this.emit("response", this.rtspStatusLine, this.rtspHeaders, []);
+            this.readState = readStates.Searching;
+          } else {
+            this.rtspContent = [];
+            this.readState = readStates.ReadingRTSPPayload;
           }
-          this.emit("data", this.packetChannel, packet.payload, packet);
         }
-        if (this.packetChannel === 1) {
-          packet = parseRTCPPacket(Buffer.concat(this.packets));
-          this.emit("controlData", this.packetChannel, packet);
+      } else if (this.readState == readStates.ReadingRTSPPayload
+        && this.rtspContent.length < this.rtspContentLength) {
+        // Copy data into the RTSP payload
+        this.rtspContent.push(data[index]);
+        index++;
+
+        if (this.rtspContent.length == this.rtspContentLength) {
+          const ascii_text = String.fromCharCode.apply(null,this.rtspContent);
+          const mediaHeaders = ascii_text.split("\n");
+
+          // Emit the RTSP message
+          this.emit("log", data, "S->C");
+          this.emit("response", this.rtspStatusLine, this.rtspHeaders, mediaHeaders);
+          this.readState = readStates.Searching;
         }
+      } else if (this.readState == readStates.ReadingRawPacketSize) {
+        // accumulate bytes for $, channel and length
+        this.rtspMessage.push(data[index]);
+        index++;
 
-        this.packets = [];
+        if (this.rtspMessage.length == 4) {
+          this.rtspPacketLength = (this.rtspMessage[2] << 8) + this.rtspMessage[3];
+          if (this.rtspPacketLength > 0) {
+            this.rtspPacket = new Buffer(this.rtspPacketLength);
+            this.rtspPacketPointer = 0;
+            this.readState = readStates.ReadingRawPacket;
+          } else {
+            this.readState = readStates.Searching;
+          }
+        }
+      } else if (this.readState == readStates.ReadingRawPacket) {
+        this.rtspPacket[this.rtspPacketPointer++] = data[index];
+        index++;
 
-        index += this.originalPacketLength;
-      }
-
-      return;
-    }
-
-    data = data.toString("utf8");
-
-    if (data.indexOf("RTSP") < 0) {
-      throw new Error("Unknown protocol? Please make sure you are connecting to an RTSP server.");
-    }
-
-    this.emit("log", data, "S->C");
-
-    const lines = data.split("\n");
-    const headers = {};
-    const mediaHeaders = [];
-
-    for (let i = 1; i < lines.length; i++) {
-      const line = lines[i];
-
-      if (line[1] === "=") {
-        mediaHeaders.push(line);
+        if (this.rtspPacketPointer == this.rtspPacketLength) {
+          const packetChannel = this.rtspMessage[1];
+          if (packetChannel === 0) {
+            const packet = parseRTPPacket(this.rtspPacket);
+            this.emit("data", packetChannel, packet.payload, packet);
+          }
+          if (packetChannel === 1) {
+            const packet = parseRTCPPacket(this.rtspPacket);
+            this.emit("controlData", packetChannel, packet);
+          }
+          this.readState = readStates.Searching;
+        }
       } else {
-        const indexOf = line.indexOf(":");
-
-        if (indexOf !== line.length - 1) {
-          const key = line.substring(0, indexOf).trim();
-          const data = line.substring(indexOf + 1).trim();
-
-          headers[key] = data.match(/^[0-9]+$/) ? parseInt(data, 10) : data;
-        }
+        // unexpected data
+        throw new Error("Bug in RTSP data framing, please file an issue with the author with stacktrace.");
       }
-    }
-
-    this.emit("response", lines[0], headers, mediaHeaders);
+    } // end while
   }
 
   connect(url) {
@@ -185,6 +217,8 @@ class RtspClient extends EventEmitter {
       client.on("data", this._onData.bind(this));
       client.on("error", errorListener);
       client.on("close", closeListener);
+//    }).then(_ => {
+//      return this.request("OPTIONS");
     }).then(_ => {
       return this.request("DESCRIBE", { Accept: "application/sdp" });
     }).then(obj => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -98,7 +98,7 @@ class RtspClient extends EventEmitter {
             if (indexOf !== line.length - 1) {
               const key = line.substring(0, indexOf).trim();
               const data = line.substring(indexOf + 1).trim();
-              this.rtspHeaders[key] = data.match(/^[0-9]+$/) ? parseInt(data, 10) : data;
+              this.rtspHeaders[key] = (key != 'Session' && data.match(/^[0-9]+$/)) ? parseInt(data, 10) : data;
 
               if (key == 'Content-Length') {
                 this.rtspContentLength = parseInt(data,10);

--- a/lib/index.js
+++ b/lib/index.js
@@ -259,7 +259,7 @@ class RtspClient extends EventEmitter {
       }
 
       const transport = parseTransport(headers.Transport);
-      this._session = headers.Session;
+      this._session = headers.Session.split(';')[0]; //'SessionId'[';timeout=seconds']
 
       return {
         format,

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ const net = require("net");
 const urlParse = require("url");
 const { EventEmitter } = require("events");
 
-const { parseRTPPacket, parseRTCPPacket, getMD5Hash, parseTransport } = require('./util.js');
+const { parseRTPPacket, parseRTCPPacket, getMD5Hash, parseTransport, generateSSRC } = require('./util.js');
 
 const transform = require("sdp-transform");
 
@@ -43,6 +43,8 @@ class RtspClient extends EventEmitter {
 
     this.headers = Object.assign({ "User-Agent": "yellowstone/2.0.0" },
         headers || {});
+
+    this.clientSSRC = generateSSRC();
   }
 
   _onData(data) {
@@ -157,6 +159,7 @@ class RtspClient extends EventEmitter {
           if (packetChannel === 1) {
             const packet = parseRTCPPacket(this.rtspPacket);
             this.emit("controlData", packetChannel, packet);
+            this.sendEmptyReceiverReport(packetChannel);
           }
           this.readState = readStates.Searching;
         }
@@ -388,6 +391,24 @@ class RtspClient extends EventEmitter {
     }
 
     return this.request("PAUSE", { Session: this._session }).then(() => this);
+  }
+
+  sendEmptyReceiverReport(channel) {
+    let report = new Buffer(8);
+    const version = 2;
+    const paddingBit = 0;
+    const reportCount = 0; // an empty report
+    const packetType = 201; // Receiver Report
+    const length = (report.length/4) - 1; // num 32 bit words minus 1
+    report[0] = (version << 6) + (paddingBit << 5) + reportCount;
+    report[1] = packetType;
+    report[2] = (length >> 8) & 0xFF;
+    report[3] = (length >> 0) & 0XFF;
+    report[4] = (this.clientSSRC >> 24) & 0xFF;
+    report[5] = (this.clientSSRC >> 16) & 0xFF;
+    report[6] = (this.clientSSRC >> 8) & 0xFF;
+    report[7] = (this.clientSSRC >> 0) & 0xFF;
+    this.sendInterleavedData(channel,report);
   }
 
   close(isImmediate) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -106,7 +106,7 @@ class RtspClient extends EventEmitter {
 
           if (this.rtspContentLength == 0) {
             // We can Emit the RTSP message
-            this.emit("log", data, "S->C");
+            this.emit("log", ascii_text, "S->C");
             this.emit("response", this.rtspStatusLine, this.rtspHeaders, []);
             this.readState = readStates.Searching;
           } else {
@@ -125,7 +125,7 @@ class RtspClient extends EventEmitter {
           const mediaHeaders = ascii_text.split("\n");
 
           // Emit the RTSP message
-          this.emit("log", data, "S->C");
+          this.emit("log", String.fromCharCode.apply(null,this.rtspMessage) + ascii_text, "S->C");
           this.emit("response", this.rtspStatusLine, this.rtspHeaders, mediaHeaders);
           this.readState = readStates.Searching;
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -360,6 +360,20 @@ class RtspClient extends EventEmitter {
     this._client.write(`${res}\r\n`);
   }
 
+  sendInterleavedData(channel, buffer) {
+    const req = buffer.length + ' bytes of interleaved data on channel '+channel;
+    this.emit("log", req, "C->S");
+
+    let header = new Buffer(4);
+    header[0] = 0x24; // ascii $
+    header[1] = channel;
+    header[2] = (buffer.length >> 8) & 0xFF;
+    header[3] = (buffer.length >> 0) & 0xFF;
+
+    const data = Buffer.concat([header,buffer]);
+    this._client.write(data);
+  }
+
   play() {
     if (!this.isConnected) {
       throw new Error("Client is not connected.");

--- a/lib/index.js
+++ b/lib/index.js
@@ -217,8 +217,8 @@ class RtspClient extends EventEmitter {
       client.on("data", this._onData.bind(this));
       client.on("error", errorListener);
       client.on("close", closeListener);
-//    }).then(_ => {
-//      return this.request("OPTIONS");
+    }).then(_ => {
+      return this.request("OPTIONS");
     }).then(_ => {
       return this.request("DESCRIBE", { Accept: "application/sdp" });
     }).then(obj => {

--- a/lib/util.js
+++ b/lib/util.js
@@ -56,9 +56,20 @@ function parseTransport(transport) {
   return obj;
 }
 
+function generateSSRC() {
+  return getRandomIntInclusive(1,0xffffffff);
+}
+
+function getRandomIntInclusive(min, max) {
+  min = Math.ceil(min);
+  max = Math.floor(max);
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
 module.exports = {
   parseRTPPacket,
   parseRTCPPacket,
   getMD5Hash,
-  parseTransport
+  parseTransport,
+  generateSSRC
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,7 +2,7 @@ const { createHash } = require("crypto");
 const { spawn } = require("child_process");
 
 function parseRTPPacket(buffer) {
-  const hasExtensions = (buffer[0] << 3) >>> 7;
+  const hasExtensions = (buffer[0] >> 4) & 0x01;
   const marker = (buffer[1]) >>> 7;
   const num_csrc_identifiers = (buffer[0] & 0x0F);
 


### PR DESCRIPTION
As TCP is a stream of data we should not rely on the read from the socket giving us a complete RTSP message. It is perfectly valid for the socket read to give part of a message, with the rest of the message in the next socket read.
It is also perfectly valid for a read from a socket to return the content of several IP packets if they are all in the receive buffer.

(this is different to UDP messaging where we get to process one IP packet at a time)

The previous code would occasionally fall over with the new wowza server when it tried to process the interleaved data but we had not received the 4 header bytes (the $, channel and 2 byte length) from the socket read. This caused the code that read the raw data length to fail.
The old code also falls over with some IP CCTV cameras I have.

This Pull Request re-implements the code that handles the socket reads so that it processes the TCP data byte by byte and the socket read can return any quantity of data from 1 byte to a whole load of IP packets.


Note there is a nice optimisation to make.
When reading the RTSP payload (e.g. the SDP) we know the expected length from Content-Length. When reading the interleaved RTP/RTCP data we also know the length.
So instead of going around the while loop once per byte, Math.Min() and an array copy can be used in a similar way to the old code.

However for now I wanted to share the current code for discussion.



