### PR TITLE
Handle Content-length bug in Hipcam RealServer/V1.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -462,7 +462,8 @@ class RtspClient extends EventEmitter {
                   ? parseInt(data, 10)
                   : data;
             
-              if (key == "Content-Length") {
+              // workaround for buggy Hipcam RealServer/V1.0 camera which returns Content-length and not Content-Length
+              if (key.toLowerCase() == "content-length") {
                 this.rtspContentLength = parseInt(data, 10);
               }
             }


### PR DESCRIPTION
Hipcam RealServer/V1.0 does not follow the RTSP standard properly.
It outputs 'Content-length'
It should be 'Content-Length'   (Capital 'L')
